### PR TITLE
v1.1 Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-# main: main.c
-# 	gcc -Wall main.c -lpthread -o DelayDaemon -lm $(shell pkg-config --cflags libevdev)
 TARGET = DelayDaemon
 
 CFLAGS = -Wall -pedantic -O3 -std=gnu11 $(shell pkg-config --cflags libevdev)

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,19 @@
-main: main.c
-	gcc -Wall main.c -lpthread -o DelayDaemon -lm
+# main: main.c
+# 	gcc -Wall main.c -lpthread -o DelayDaemon -lm $(shell pkg-config --cflags libevdev)
+TARGET = DelayDaemon
+
+CFLAGS = -Wall -pedantic -O3 -std=gnu11 $(shell pkg-config --cflags libevdev)
+LDFLAGS = $(shell pkg-config --libs libevdev)
+LIBS = -pthread -lm
+
+OBJECTS = \
+	main.o
+
+$(TARGET) : $(OBJECTS)
+	$(CC) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+%.o : %.c
+	$(CC) $(CFLAGS)  -o $@ -c $<
+
+clean :
+	rm -f $(TARGET) *.o

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ LDFLAGS = $(shell pkg-config --libs libevdev)
 LIBS = -pthread -lm
 
 OBJECTS = \
+	log.o \
+	args.o \
 	main.o
 
 $(TARGET) : $(OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 main: main.c
-	gcc -Wall main.c -lpthread -o DelayDaemon
+	gcc -Wall main.c -lpthread -o DelayDaemon -lm

--- a/README.md
+++ b/README.md
@@ -5,41 +5,55 @@ It grabs all input events from the specified input device and blocks them from b
 A new virtual input device is created and grabbed events are passed to this device after a certain delay.
 
 It is possible to add a fixed delay to all events (by using the same value for **min** and **max**) or a range of possible delay times which leads to a distribution.
-For now, only an even distribution is implemented.
+Delays within range can distributed linearly or normally.
 
 The delays for click events and movement events can be set separately.
 Note that a varying delay for movement events leads to stuttering mouse movement.
 
 The delay times can also be changed during runtime using a FIFO.
 
+This program must be run as superuser, unless your user has permissions to access uinput.
+
 ## Usage:
-
 ```
-DelayDaemon [event_handle] [min_delay_click] [max_delay_click] [min_delay_move] [max_delay_move] [fifo_path]
+DelayDaemon [OPTION...]
+            --input <FILE> --min_key_delay <NUM> --max_key_delay <NUM>
+```
+```
+-0, --min_key_delay=NUM    Minimum delay for keys/clicks
+-1, --max_key_delay=NUM    Maximum delay for keys/clicks
+-2, --min_move_delay=NUM   Minimum delay for mouse movement
+-3, --max_move_delay=NUM   Maximum delay for mouse movement
+-d, --distribution[=STRING]   [linear] (default) or [normal] distributed
+                             random values
+-f, --fifo[=FILE]          path to the fifo file
+-i, --input=FILE           /dev/input/eventX
+-m, --mean[=NUM]           target mean value for normal distribution
+-s, --std[=NUM]            target standard distribution for normal
+                             distribution
+-v, --verbose              turn on debug prints
+-?, --help                 Give this help list
+    --usage                Give a short usage message
+-V, --version              Print program version
+```
+Example:
+```
+sudo ./DelayDaemon -0 0 -1 100 -2 0 -3 200 -i /dev/input/event6 
 ```
 
- * **event_handle**: path to input device, e.g. `/dev/input/event5`
- * **min_delay_click**: minimum delay to be added to mouse clicks (in milliseconds)
- * **max_delay_click**: maximum delay to be added to mouse clicks (in milliseconds)
- * **min_delay_move**: minimum delay to be added to mouse movement (in milliseconds)
- * **max_delay_move**: maximum delay to be added to mouse movement (in milliseconds)
- * **fifo_path**: path to a FIFO used to remotely set delay times during runtime (optional)
+This will set each click delay to a random value between 0 and 100 and each mouse movement to a random value between 0 and 200 for the input device corresponding to event6.
 
 ## Remotely Controlling Delay Times
 
-If **fifo_path** is set, a FIFO is created at this path.
+If `--fifo` is set, a FIFO is created at this path.
 By writing into this FIFO (which can be done with normal file operations), delay times can be changed during runtime.
 The new values have to be written to the FIFO seperated by whitespaces and all four values have to be set.
 
 **Example:**
 
 ```
-./DelayDaemon /dev/input/event5 100 200 0 0 /tmp/delaydaemon
+sudo ./DelayDaemon -i /dev/input/event6 -0 100 -1 200 -2 0 -3 0 -f /tmp/delaydaemon
 echo "200 300 0 0" > /tmp/delaydaemon
 ```
 
 This would start the program with a click delay of 100-200 ms and then increase the delay to 200-300 ms.
-
-## Future Work:
-
- * add the possibility to use different distributions (like gaussian)

--- a/args.c
+++ b/args.c
@@ -46,7 +46,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         args->max_move_delay = strtol(arg, NULL, 10);
         break;
     case 'd':
-        args->distribution = arg;
+        args->distribution = arg + 1;   // skip the '=' character
         break;
     case 'm':
         args->mean = strtol(arg, NULL, 10);
@@ -55,7 +55,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         args->std = strtol(arg, NULL, 10);
         break;
     case 'f':
-        args->fifo_path = arg;
+        args->fifo_path = arg +1;
         break;
     case 'v':
         args->verbose = 1;
@@ -68,31 +68,25 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
 		}
 
-		/* Check if delay is specified. */
-		if (args->min_key_delay == 0 && args->max_key_delay == 0)
-        {
-			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
-		}
-        else if(args->min_key_delay > 0 && args->max_key_delay == 0)
+        if(args->min_key_delay > 0 && args->max_key_delay == 0)
         {
             args->max_key_delay = args->min_key_delay;
         }
         // set default values if none specified
-        if(strcmp(args->distribution, "normal"))
+        if(strcmp(args->distribution, "normal") == 0)
         {
             if(args->mean == 0) args->mean = (args->max_key_delay + args->min_key_delay) / 2;
             if(args->std == 0) args->std = args->mean / 10;
-        }
 
-        if(args->mean > args->max_key_delay
-        || args->mean < args->min_key_delay
-        ||(args->mean > args->max_move_delay && args->max_move_delay > 0)   // since move delay is optional and can be 0
-        || args->mean < args->min_move_delay)
-        {
-            printf("Illegal value for mu. Average must be between min and max delay!\n");
-            return 1;
+            if(args->mean > args->max_key_delay
+            || args->mean < args->min_key_delay
+            ||(args->mean > args->max_move_delay && args->max_move_delay > 0)   // since move delay is optional and can be 0
+            || args->mean < args->min_move_delay)
+            {
+                printf("Illegal value for mu. Average must be between min and max delay!\n");
+                return 1;
+            }
         }
-
 		break;
 	}
 

--- a/args.c
+++ b/args.c
@@ -58,7 +58,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         args->fifo_path = arg;
         break;
     case 'v':
-        args->verbose = strtol(arg, NULL, 10);
+        args->verbose = 1;
         break;
 	case ARGP_KEY_END:
 

--- a/args.c
+++ b/args.c
@@ -1,0 +1,107 @@
+#include "args.h"
+
+static char doc[] =
+	"DelayDaemon 1.1 -- A GNU/Linux tool to add (varying) latency to input devices\n"
+	"Run as superuser!\n";
+
+const char *argp_program_version =
+	"DelayDaemon 1.1";
+
+static char args_doc[] =
+	"--input <FILE> --min_key_delay <NUM> --max_key_delay <NUM>";
+
+static struct argp_option options[] =
+{
+	{"input", 'i', "FILE", 0, "/dev/input/eventX"},
+	{"min_key_delay", '0', "NUM", 0, "Minimum delay for keys/clicks"},
+	{"max_key_delay", '1', "NUM", 0, "Maximum delay for keys/clicks"},
+	{"min_move_delay", '2', "NUM", 0, "Minimum delay for mouse movement"},
+	{"max_move_delay", '3', "NUM", 0, "Maximum delay for mouse movement"},
+	{"distribution", 'd', "STRING", OPTION_ARG_OPTIONAL, "[linear] (default) or [normal] distributed random values"},
+	{"mean", 'm', "NUM", OPTION_ARG_OPTIONAL, "target mean value for normal distribution"},
+	{"std", 's', "NUM", OPTION_ARG_OPTIONAL, "target standard distribution for normal distribution"},
+	{"fifo", 'f', "FILE", OPTION_ARG_OPTIONAL, "path to the fifo file"},
+	{"verbose", 'v', "NUM", OPTION_ARG_OPTIONAL, "turn on debug prints"},
+	{0}
+};
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state)
+{
+	struct arguments *args = state->input;
+
+	switch (key) {
+	case 'i':
+        args->device_file = arg;
+        break;
+    case '0':
+        args->min_key_delay = strtol(arg, NULL, 10);
+        break;
+    case '1':
+        args->max_key_delay = strtol(arg, NULL, 10);
+        break;
+    case '2':
+        args->min_move_delay = strtol(arg, NULL, 10);
+        break;
+    case '3':
+        args->max_move_delay = strtol(arg, NULL, 10);
+        break;
+    case 'd':
+        args->distribution = arg;
+        break;
+    case 'm':
+        args->mean = strtol(arg, NULL, 10);
+        break;
+    case 's':
+        args->std = strtol(arg, NULL, 10);
+        break;
+    case 'f':
+        args->fifo_path = arg;
+        break;
+    case 'v':
+        args->verbose = strtol(arg, NULL, 10);
+        break;
+	case ARGP_KEY_END:
+
+		/* Check if file is specified. */
+		if (args->device_file == NULL)
+        {
+			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+		}
+
+		/* Check if delay is specified. */
+		if (args->min_key_delay == 0 && args->max_key_delay == 0)
+        {
+			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+		}
+        else if(args->min_key_delay > 0 && args->max_key_delay == 0)
+        {
+            args->max_key_delay = args->min_key_delay;
+        }
+        // set default values if none specified
+        if(strcmp(args->distribution, "normal"))
+        {
+            if(args->mean == 0) args->mean = (args->max_key_delay + args->min_key_delay) / 2;
+            if(args->std == 0) args->std = args->mean / 10;
+        }
+
+        if(args->mean > args->max_key_delay
+        || args->mean < args->min_key_delay
+        ||(args->mean > args->max_move_delay && args->max_move_delay > 0)   // since move delay is optional and can be 0
+        || args->mean < args->min_move_delay)
+        {
+            printf("Illegal value for mu. Average must be between min and max delay!\n");
+            return 1;
+        }
+
+		break;
+	}
+
+	return 0;
+}
+
+error_t parse_args(int argc, char **argv, struct arguments *args)
+{
+	struct argp argp = {options, parse_opt, args_doc, doc};
+
+	return argp_parse(&argp, argc, argv, 0, 0, args);
+}

--- a/args.c
+++ b/args.c
@@ -2,7 +2,7 @@
 
 static char doc[] =
 	"DelayDaemon 1.1 -- A GNU/Linux tool to add (varying) latency to input devices\n"
-	"Run as superuser!\n";
+	"Run as superuser\n";
 
 const char *argp_program_version =
 	"DelayDaemon 1.1";
@@ -21,7 +21,7 @@ static struct argp_option options[] =
 	{"mean", 'm', "NUM", OPTION_ARG_OPTIONAL, "target mean value for normal distribution"},
 	{"std", 's', "NUM", OPTION_ARG_OPTIONAL, "target standard distribution for normal distribution"},
 	{"fifo", 'f', "FILE", OPTION_ARG_OPTIONAL, "path to the fifo file"},
-	{"verbose", 'v', "NUM", OPTION_ARG_OPTIONAL, "turn on debug prints"},
+	{"verbose", 'v', NULL, OPTION_ARG_OPTIONAL, "turn on debug prints"},
 	{0}
 };
 

--- a/args.h
+++ b/args.h
@@ -1,0 +1,24 @@
+#ifndef _ARGS_H_
+#define _ARGS_H_
+
+#include <stdlib.h>
+#include <argp.h>
+#include <string.h>
+
+struct arguments
+{
+    char* device_file;
+    int min_key_delay;
+    int max_key_delay;
+    int min_move_delay;
+    int max_move_delay;
+    char* distribution;
+    float mean;
+    float std;
+    char* fifo_path;
+    int verbose;
+};
+
+error_t parse_args(int argc, char **argv, struct arguments *arg);
+
+#endif

--- a/log.c
+++ b/log.c
@@ -1,0 +1,56 @@
+#include "log.h"
+
+const char* log_file = "event_log.csv";
+
+// https://stackoverflow.com/a/3536261
+void init_vector(event_vector *ev, size_t size)
+{
+    ev->events = malloc(size * sizeof(delayed_event));
+    ev->used = 0;
+    ev->size = size;
+}
+
+void append_to_vector(event_vector *ev, delayed_event event)
+{
+    // upgrade allocated memory if necessary
+    if(ev->used >= ev->size)
+    {
+        ev->size *= 2;
+        ev->events = realloc(ev->events, ev->size * sizeof(delayed_event));
+    }
+    ev->events[ev->used++] = event;
+}
+
+void free_vector(event_vector *ev)
+{
+    free(ev->events);
+    ev->events = NULL;
+    ev->used = ev->size = 0;
+}
+
+void write_event_log(event_vector *ev)
+{
+    // write header if file doesn't exist
+    if(access(log_file, F_OK) != 0)
+    {
+        FILE *file = fopen(log_file, "w+");
+        const char* header = "timestamp;delay;type;value;code\n";
+        fwrite(header, 1, strlen(header), file);
+        fclose(file);
+    }
+
+    FILE *file = fopen(log_file, "a");
+    for(int i=0; i<ev->used; ++i)
+    {
+        delayed_event evnt = ev->events[i];
+        fprintf(file,
+                "%lu;%i;%i;%i;%i\n",
+                evnt.timestamp,
+                evnt.delay,
+                evnt.type,
+                evnt.value,
+                evnt.code);
+    }
+    fclose(file);
+    free_vector(ev);
+}

--- a/log.h
+++ b/log.h
@@ -1,0 +1,30 @@
+#ifndef _LOG_H_
+#define _LOG_H_
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+typedef struct
+{
+    int type;                   // event type (e.g. key press, relative movement, ...)
+    int code;                   // event code (e.g. for key pressses the key/button code)
+    int value;                  // event value (e.g. 0/1 for button up/down, coordinates for absolute movement, ...)
+    int delay;                  // delay time for the event in milliseconds
+    unsigned long timestamp;    // time the event occured
+} delayed_event;
+
+typedef struct
+{
+    size_t size;
+    size_t used;
+    delayed_event* events;
+} event_vector;
+
+void init_vector(event_vector *ev, size_t size);
+void append_to_vector(event_vector *ev, delayed_event event);
+void free_vector(event_vector *ev);
+void write_event_log(event_vector *ev);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -278,6 +278,7 @@ int main(int argc, char* argv[])
     args.max_key_delay = 0;
     args.min_move_delay = 0;
     args.max_move_delay = 0;
+    args.fifo_path = NULL;
     args.distribution = "";
 
 	if (parse_args(argc, argv, &args) < 0) {
@@ -293,8 +294,9 @@ int main(int argc, char* argv[])
     max_delay_move = args.max_move_delay;
     mu = args.mean;
     sigma = args.std;
-    if(strcmp(args.distribution, "normal")) distribution = normal;
+    if(strcmp(args.distribution, "normal") == 0) distribution = normal;
     else distribution = linear;
+    if(args.fifo_path) fifo_path = args.fifo_path;
     DEBUG = args.verbose;
 
     // prevents Keydown events for KEY_Enter from never being released when grabbing the input device
@@ -305,6 +307,10 @@ int main(int argc, char* argv[])
     init_vector(&ev, 10);
     if(!init_input_device()) return 1;
     if(!init_virtual_input()) return 1;
+    if(fifo_path != NULL && fifo_path[0] != '\0')
+    {
+        if(!init_fifo()) return 1;
+    }
 
     if(distribution==normal && DEBUG) printf("Normal distribution: mean: %lf, std: %lf\n", mu, sigma);
 

--- a/main.c
+++ b/main.c
@@ -176,6 +176,7 @@ int calculate_delay(int min, int max)
         {
             x = randn(mu, sigma);
         }
+        printf("%d\n", x);
         return x;
     }
     else return 0;
@@ -437,11 +438,21 @@ int main(int argc, char* argv[])
 
     if(argc > 8)
     {
+        sscanf(argv[8], "%lf", &mu);
+        sscanf(argv[9], "%lf", &sigma);
+    }
+    else
+    {
         // if mean for normal distribution is not specified, default to the mean of min and max delay
-        if(sscanf(argv[8], "%lf", &mu) == EOF) mu = (max_delay_click - min_delay_click) / 2;
-
+        mu = (max_delay_click + min_delay_click) / 2;
         // if not specified, default to 10% std
-        if(sscanf(argv[9], "%lf", &sigma) == EOF) sigma = (max_delay_click - min_delay_click) / 10;
+        sigma = mu / 20; 
+    }
+
+    if(mu>max_delay_click || mu<min_delay_click)
+    {
+        printf("Illegal value for mu. Average must be between min and max delay!\n");
+        return 1;
     }
 
     if(DEBUG) printf("click delay: %d - %d\nmove delay: %d - %d\n", min_delay_click, max_delay_click, min_delay_move, max_delay_move);
@@ -450,6 +461,8 @@ int main(int argc, char* argv[])
 
     struct input_event inputEvent;
     int err = -1;
+
+    printf("mu: %lf, sigma: %lf\n", mu, sigma);
 
     pthread_attr_setdetachstate(&invoked_event_thread_attr, PTHREAD_CREATE_DETACHED);
     pthread_attr_setdetachstate(&log_delay_val_thread_attr, PTHREAD_CREATE_DETACHED);

--- a/main.c
+++ b/main.c
@@ -239,6 +239,8 @@ void *invoke_delayed_evdev_event(void *args)
                     strerror(-rc));
     }
 
+    rc = libevdev_uinput_write_event(uinput_dev, EV_SYN, SYN_REPORT, 0);
+
     // emit(eventFd, eventType, eventCode, eventValue); // this is the actual delayed input event (eg. mouse move or click)
     // emit(eventFd, EV_SYN, SYN_REPORT, 0); // EV_SYN events have to come in time so we trigger them manually
 
@@ -592,13 +594,13 @@ int main(int argc, char* argv[])
     // when new event arrives, generate a delay value and create a thread waiting for this delay time
     // the thread then generates an input event for a virtual input device
     // note EV_SYN events are NOT delayed, they are automatically generated when the delayed event is executed
-    // while(err = read(fd_rtc, NULL, sizeof(unsigned long)))
-    while(1)
+    while(err = read(fd_rtc, NULL, sizeof(unsigned long)))
+    // while(1)
     {
         // err = read(fd_event, &inputEvent, sizeof(struct input_event));
         // err = get_event(&inputEvent);
         err = get_event(&inputEvent);
-        if(err > -1)
+        if(err > -1 && inputEvent.type != EV_SYN)
         // if(err > -1 && inputEvent.type != EV_SYN && inputEvent.type != EV_MSC) // I have no idea what EV_MSC is but it freezes the application (MSC_SCAN!) when moving fast
 		{
             delayed_event *event = malloc(sizeof(delayed_event));

--- a/main.c
+++ b/main.c
@@ -45,7 +45,7 @@ typedef struct
     delayed_event* events;
 } event_vector;
 
-event_vector *ev;     // vector of all input events
+event_vector ev;     // vector of all input events
 int input_fd = -1;   // actual input device
 int virtual_fd = -1; // virtual device for delayed events
 int fifo_fd = -1;    // path to FIFO for remotely controlled delay times
@@ -309,7 +309,7 @@ void onExit(int signum)
     ioctl(virtual_fd, UI_DEV_DESTROY);
     close(virtual_fd);
 
-    write_event_log(ev);
+    write_event_log(&ev);
 
     exit(EXIT_SUCCESS);
 }
@@ -337,7 +337,7 @@ int main(int argc, char* argv[])
 
     event_handle = argv[1];
 
-    init_vector(ev, 100);
+    init_vector(&ev, 100);
 
     // prevents Keydown events for KEY_Enter from never being released when grabbing the input device
     // after running the program in a terminal by pressing Enter
@@ -391,7 +391,7 @@ int main(int argc, char* argv[])
 	        pthread_create(&delayed_event_thread, &invoked_event_thread_attr, invoke_delayed_event, event);
 
             event->timestamp = inputEvent.time.tv_sec * 1000 + inputEvent.time.tv_usec / 1000;
-            append_to_vector(ev, *event);
+            append_to_vector(&ev, *event);
         }
     }
 

--- a/main.c
+++ b/main.c
@@ -331,7 +331,7 @@ int main(int argc, char* argv[])
     while(1)
     {
         err = get_event(&inputEvent);
-        if(err > -1 && inputEvent.type != EV_SYN)
+        if(err > -1 && inputEvent.type != EV_SYN && inputEvent.type != EV_MSC)
 		{
             delayed_event *event = malloc(sizeof(delayed_event));
             event->type = inputEvent.type;

--- a/main.c
+++ b/main.c
@@ -26,7 +26,7 @@
 #include <signal.h>
 
 // set to 1 for more verbose console output
-#define DEBUG 0
+#define DEBUG 1
 
 typedef struct
 {
@@ -100,8 +100,8 @@ void write_event_log(event_vector *ev)
     if(access(log_file, F_OK) != 0)
     {
         FILE *file = fopen(log_file, "w+");
-        const char* header = "timestamp;delay;type;value;code";
-        fwrite(header, 1, sizeof(header), file);
+        const char* header = "timestamp;delay;type;value;code\n";
+        fwrite(header, 1, strlen(header), file);
         fclose(file);
     }
 
@@ -301,6 +301,8 @@ int init_input_device()
 // make sure to clean up when the program ends
 void onExit(int signum)
 {
+    write_event_log(&ev);
+    printf("foo");
     // end inter process communication
     pthread_cancel(fifo_thread);
     unlink(fifo_path);
@@ -309,7 +311,6 @@ void onExit(int signum)
     ioctl(virtual_fd, UI_DEV_DESTROY);
     close(virtual_fd);
 
-    write_event_log(&ev);
 
     exit(EXIT_SUCCESS);
 }
@@ -337,7 +338,7 @@ int main(int argc, char* argv[])
 
     event_handle = argv[1];
 
-    init_vector(&ev, 100);
+    init_vector(&ev, 10);
 
     // prevents Keydown events for KEY_Enter from never being released when grabbing the input device
     // after running the program in a terminal by pressing Enter


### PR DESCRIPTION
v1.1 brought the following changes:

- fixed DelayDaemon events passed with delay=0 experiencing unwanted base delay of up to 50 ms in some cases.
- DelayDaemon now accurately clones the passed input device, instead of creating a new one and enabling some keypresses manually.
- add keyboard support
- arguments are now handled via `argp`. This replaces positional args with kwargs and allows for more optional arguments to be used.
- random delays are now distributed linearly by default.
- added option to normally distribute random delays.
- added mean and std variables to change the normal distribution.